### PR TITLE
[codex] 修复 NeoForge 1.21.1 构件元数据

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,9 @@ neoForge {
     }
 }
 
-sourceSets.main.resources { srcDir 'src/generated/resources' }
+sourceSets.main.resources {
+    srcDir 'src/generated/resources'
+}
 
 configurations {
     runtimeClasspath.extendsFrom localRuntime
@@ -93,6 +95,9 @@ dependencies {
     implementation("net.createmod.ponder:Ponder-NeoForge-${minecraft_version}:${ponder_version}")
     compileOnly("dev.engine-room.flywheel:flywheel-neoforge-api-${flywheel_minecraft_version}:${flywheel_version}")
     compileOnly "curse.maven:irisshaders-455508:6661598"
+    testImplementation platform('org.junit:junit-bom:5.11.4')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {
@@ -112,6 +117,9 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
     into "build/generated/sources/modMetadata"
 }
 
+sourceSets.main.resources.srcDir generateModMetadata
+neoForge.ideSyncTask generateModMetadata
+
 publishing {
     publications {
         register('mavenJava', MavenPublication) {
@@ -127,6 +135,16 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+}
+
+def modJar = tasks.named('jar', Jar)
+def modJarPath = modJar.get().archiveFile.get().asFile.absolutePath
+
+tasks.named('test', Test) {
+    dependsOn modJar, testClasses
+    useJUnitPlatform()
+    systemProperty 'maidRestaurant.jar', modJarPath
+    systemProperty 'maidRestaurant.version', project.mod_version
 }
 
 idea {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ loader_version_range=[1,)
 
 mod_id=maid_restaurant
 mod_name=Maid Restaurant
-mod_license=All Rights Reserved
-mod_version=0.2.8
+mod_license=BSD 3-Clause
+mod_version=0.2.10
 mod_group_id=com.mastermarisa.maid_retaurant

--- a/src/main/java/com/mastermarisa/maid_restaurant/network/NetworkHandler.java
+++ b/src/main/java/com/mastermarisa/maid_restaurant/network/NetworkHandler.java
@@ -41,7 +41,7 @@ public class NetworkHandler {
                 SendOrderPayload.STREAM_CODEC,
                 (payload, context) -> {
                     context.enqueueWork(() -> {
-                        handleSendOrdersOnServer(payload,context);
+                        handleSendOrdersOnServer(payload, context);
                     });
                 }
         );
@@ -51,7 +51,7 @@ public class NetworkHandler {
                 ModifyAttributePayload.STREAM_CODEC,
                 (payload, context) -> {
                     context.enqueueWork(() -> {
-                        handleModifyAttributesOnServer(payload,context);
+                        handleModifyAttributesOnServer(payload, context);
                     });
                 }
         );
@@ -61,7 +61,7 @@ public class NetworkHandler {
                 CancelRequestPayload.STREAM_CODEC,
                 (payload, context) -> {
                     context.enqueueWork(() -> {
-                        handleCancelRequestOnServer(payload,context);
+                        handleCancelRequestOnServer(payload, context);
                     });
                 }
         );
@@ -71,7 +71,7 @@ public class NetworkHandler {
                 ChangeHandlerAcceptValuePayload.STREAM_CODEC,
                 (payload, context) -> {
                     context.enqueueWork(() -> {
-                        handleChangeHandlerAcceptValueOnServer(payload,context);
+                        handleChangeHandlerAcceptValueOnServer(payload, context);
                     });
                 }
         );

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -1,11 +1,11 @@
 modLoader="javafml"
 loaderVersion="${loader_version_range}"
-license="BSD 3-Clause"
+license="${mod_license}"
 
 [[mods]]
 
 modId="maid_restaurant"
-version="0.2.8"
+version="${mod_version}"
 displayName="Maid Restaurant"
 logoFile="logo.png"
 authors="摸里傻"

--- a/src/test/java/com/mastermarisa/maid_restaurant/packaging/ModMetadataContractTest.java
+++ b/src/test/java/com/mastermarisa/maid_restaurant/packaging/ModMetadataContractTest.java
@@ -1,0 +1,53 @@
+package com.mastermarisa.maid_restaurant.packaging;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.junit.jupiter.api.Test;
+
+public final class ModMetadataContractTest {
+    ModMetadataContractTest() {
+    }
+
+    @Test
+    void builtJarTargetsNeoForge1211() throws IOException {
+        verify(
+                Path.of(System.getProperty("maidRestaurant.jar")),
+                System.getProperty("maidRestaurant.version")
+        );
+    }
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 2) {
+            throw new IllegalArgumentException("Expected <jar-path> <mod-version>");
+        }
+
+        verify(Path.of(args[0]), args[1]);
+    }
+
+    private static void verify(Path jarPath, String expectedVersion) throws IOException {
+        try (ZipFile jar = new ZipFile(jarPath.toFile())) {
+            require(jar.getEntry("META-INF/mods.toml") == null,
+                    "Legacy Forge metadata META-INF/mods.toml must not be packaged");
+
+            ZipEntry metadataEntry = jar.getEntry("META-INF/neoforge.mods.toml");
+            require(metadataEntry != null,
+                    "NeoForge metadata META-INF/neoforge.mods.toml is missing");
+
+            String metadata = new String(jar.getInputStream(metadataEntry).readAllBytes(), StandardCharsets.UTF_8);
+            require(metadata.contains("license=\"BSD 3-Clause\""), "BSD 3-Clause license is missing");
+            require(metadata.contains("modId=\"maid_restaurant\""), "Mod id is missing");
+            require(metadata.contains("version=\"" + expectedVersion + "\""), "Mod version is stale");
+            require(metadata.contains("modId=\"neoforge\""), "NeoForge dependency is missing");
+            require(metadata.contains("versionRange=\"[1.21.1]\""), "Minecraft 1.21.1 range is missing");
+        }
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}


### PR DESCRIPTION
## 问题

Minecraft 1.21.1 / NeoForge 21.1.241 加载了版本号更高但实际面向 Forge 47 / Minecraft 1.20.1 的 `maid_restaurant-0.2.9.jar`。NeoForge 因 JAR 仅包含旧的 `META-INF/mods.toml` 而拒绝加载；后续出现的 Sodium 配置异常是加载流程受损后的次生现象。

## 变更

- 将 NeoForge 1.21.1 构件版本提升到 `0.2.10`，避免被旧平台 `0.2.9` 构件覆盖选择。
- 通过 Gradle 属性生成 `META-INF/neoforge.mods.toml`，统一版本、许可证和平台范围。
- 添加 JAR 元数据契约测试，拒绝旧 Forge 元数据并校验 NeoForge、Minecraft 1.21.1、版本及许可证。
- 修正 `NetworkHandler.java` 文件名大小写，解除 Java 编译阻塞。

## 验证

- RED：对日志中的 `maid_restaurant-0.2.9.jar` 运行契约测试，退出码 `1`，检测到 `META-INF/mods.toml`。
- GREEN：`gradlew.bat clean check --no-daemon`，退出码 `0`。
- 生成构件仅包含 `META-INF/neoforge.mods.toml`，声明 NeoForge `[21.1.217,)`、Minecraft `[1.21.1]`、版本 `0.2.10` 和 BSD 3-Clause。
- 构件 SHA-256：`ED8079A215A3729DC7BA7A1F1D6C50CEF4EAA7F96D81EF3A44BD2F983040E9D3`。

## 剩余风险

未在完整的 Ozone Skyblock Reborn 2.2 整合包中进行启动验证；当前验证覆盖编译、打包和 NeoForge 元数据加载前提。
